### PR TITLE
Conf tablas BBDD

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   mysql:
     image: mysql:8.0
@@ -16,7 +14,7 @@ services:
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p$$MYSQL_ROOT_PASSWORD"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-prootpassword"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/init.sql
+++ b/init.sql
@@ -1,5 +1,29 @@
-CREATE TABLE IF NOT EXISTS escape_rooms (
+CREATE TABLE IF NOT EXISTS escape_room (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(255) NOT NULL UNIQUE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS room (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    escape_room_id BIGINT,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    FOREIGN KEY (escape_room_id) REFERENCES escape_room(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS clue (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    room_id BIGINT,
+    description TEXT NOT NULL,
+    solution VARCHAR(255),
+    FOREIGN KEY (room_id) REFERENCES room(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS decoration (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    room_id BIGINT,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    FOREIGN KEY (room_id) REFERENCES room(id) ON DELETE CASCADE
 );


### PR DESCRIPTION
T001: Implementación de creación de Escape Rooms con persistencia en BD

## Épica T001 Completada

### Criterios de Aceptación Cumplidos:
✅ No se admiten nombres vacíos
✅ No se admiten nombres duplicados  
✅ No se admiten ER nulos
✅ Se guarda en base de datos

### Cambios Realizados:
- Configuración de conexión a base de datos MySQL
- Implementación de EscapeRoomDAO con persistencia
- Tests de integración con base de datos
- Estructura de tablas: escape_room, room, clue, decoration
- Configuración Docker y script de inicialización

### Verificación:
- Todos los tests de EscapeRoom (EscapeRoomDAOImplTest, EscapeRoomServiceTest) pasan correctamente
- Conexión a BD verificada
- Persistencia funcionando
